### PR TITLE
HEL-164: Fix Yup email validation allowing invalid addresses

### DIFF
--- a/client/src/components/FormsUI/Yup/index.ts
+++ b/client/src/components/FormsUI/Yup/index.ts
@@ -21,8 +21,7 @@ export const REGISTER_FORM_VALIDATION = Yup.object().shape({
     .max(100, "Must be less than 100 characters"),
   email: Yup.string()
     .required("Email is required")
-    .email("Invalid email address")
-    .max(255, "Must be less than 255 characters"),
+    .matches(/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/, "Invalid email address"),
   password: Yup.string()
     .required("Password is required")
     .min(8, "Password must be at least 8 characters")
@@ -45,7 +44,7 @@ export const INITIAL_LOGIN_FORM_STATE = {
 export const LOGIN_FORM_VALIDATION = Yup.object().shape({
   email: Yup.string()
     .required("Email is required")
-    .email("Invalid email address"),
+    .matches(/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/, "Invalid email address"),
   password: Yup.string().required("Password is required"),
 });
 

--- a/client/src/components/FormsUI/Yup/index.ts
+++ b/client/src/components/FormsUI/Yup/index.ts
@@ -3,6 +3,12 @@ import * as Yup from "yup";
 // Email Regex
 export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
 
+// Email validation
+export const emailValidationSchema = Yup.string()
+  .required("Email is required")
+  .matches(EMAIL_REGEX, "Invalid email address")
+  .max(255, "Must be less than 255 characters");
+
 // ---------------------------
 // Register Initial Values
 // ---------------------------
@@ -22,10 +28,7 @@ export const REGISTER_FORM_VALIDATION = Yup.object().shape({
   companyName: Yup.string()
     .required("Company name is required")
     .max(100, "Must be less than 100 characters"),
-  email: Yup.string()
-    .required("Email is required")
-    .matches(EMAIL_REGEX, "Invalid email address")
-    .max(255, "Must be less than 255 characters"),
+  email: emailValidationSchema,
   password: Yup.string()
     .required("Password is required")
     .min(8, "Password must be at least 8 characters")
@@ -46,10 +49,7 @@ export const INITIAL_LOGIN_FORM_STATE = {
 
 // Login Validation Schema
 export const LOGIN_FORM_VALIDATION = Yup.object().shape({
-  email: Yup.string()
-    .required("Email is required")
-    .matches(EMAIL_REGEX, "Invalid email address")
-    .max(255, "Must be less than 255 characters"),
+  email: emailValidationSchema,
   password: Yup.string().required("Password is required"),
 });
 
@@ -61,10 +61,7 @@ export const INITIAL_FORGOT_PASS_STATE = {
 };
 
 export const FORGOT_PASS_FORM_VALIDATION = Yup.object().shape({
-  email: Yup.string()
-    .required("Email is a required field")
-    .matches(EMAIL_REGEX, "Invalid email address")
-    .max(255, "Must be less than 255 characters"),
+  email: emailValidationSchema,
 });
 
 // ---------------------------

--- a/client/src/components/FormsUI/Yup/index.ts
+++ b/client/src/components/FormsUI/Yup/index.ts
@@ -1,5 +1,8 @@
 import * as Yup from "yup";
 
+// Email Regex
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+
 // ---------------------------
 // Register Initial Values
 // ---------------------------
@@ -21,7 +24,8 @@ export const REGISTER_FORM_VALIDATION = Yup.object().shape({
     .max(100, "Must be less than 100 characters"),
   email: Yup.string()
     .required("Email is required")
-    .matches(/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/, "Invalid email address"),
+    .matches(EMAIL_REGEX, "Invalid email address")
+    .max(255, "Must be less than 255 characters"),
   password: Yup.string()
     .required("Password is required")
     .min(8, "Password must be at least 8 characters")
@@ -44,7 +48,8 @@ export const INITIAL_LOGIN_FORM_STATE = {
 export const LOGIN_FORM_VALIDATION = Yup.object().shape({
   email: Yup.string()
     .required("Email is required")
-    .matches(/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/, "Invalid email address"),
+    .matches(EMAIL_REGEX, "Invalid email address")
+    .max(255, "Must be less than 255 characters"),
   password: Yup.string().required("Password is required"),
 });
 
@@ -58,7 +63,8 @@ export const INITIAL_FORGOT_PASS_STATE = {
 export const FORGOT_PASS_FORM_VALIDATION = Yup.object().shape({
   email: Yup.string()
     .required("Email is a required field")
-    .email("Invalid email address"),
+    .matches(EMAIL_REGEX, "Invalid email address")
+    .max(255, "Must be less than 255 characters"),
 });
 
 // ---------------------------


### PR DESCRIPTION
This PR improves email format validation in both the registration and login forms by applying a stricter regex-based rule. While the backend performs its own validation, this ensures users receive immediate client-side feedback when entering invalid email formats (e.g., example@gmail without a domain extension).


**Changes**
- Updated Yup email validation for:
- REGISTER_FORM_VALIDATION
- LOGIN_FORM_VALIDATION
- Replaced default .email() check with a stricter .matches() rule to catch edge cases