### PR TITLE
HEL-170: Prevent login page flash on reload using tri-state auth check

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,9 +13,9 @@ import { fetchCurrentUser } from "./redux/store/auth/auth-actions";
 import Message from "./components/Message";
 import type { AppDispatch, RootState } from "./redux/store";
 import ThemeSwitch from "./components/ThemeSwitch";
+import { CircularProgress } from "@mui/material";
 
 // Extending theme
-
 declare module "@mui/material/styles" {
   interface Theme {
     custom: {
@@ -89,7 +89,7 @@ const darkTheme = createTheme({
 
 function App() {
   const dispatch = useDispatch<AppDispatch>();
-  const { user } = useSelector((state: RootState) => state.auth);
+  const { user, isLoggedIn } = useSelector((state: RootState) => state.auth);
   const { type, message } = useSelector((state: RootState) => state.message);
 
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -101,6 +101,22 @@ function App() {
       dispatch(fetchCurrentUser());
     }
   }, [dispatch, user]);
+
+  // Until logged in state in determined
+  if (isLoggedIn === undefined) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100vh", // full screen
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
 
   return (
     <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -5,9 +5,9 @@ import { useLocation, useNavigate } from "react-router-dom";
 
 // Redux
 import { useDispatch, useSelector } from "react-redux";
+import type { AppDispatch, RootState } from "../redux/store";
 import { loginUser } from "../redux/store/auth/auth-actions";
 import { clearStatus } from "../redux/store/auth/auth-slice";
-import type { RootState, AppDispatch } from "../redux/store";
 
 // Formik and yup
 import { Formik, Form as FormikForm, type FormikHelpers } from "formik";
@@ -17,17 +17,17 @@ import {
 } from "../components/FormsUI/Yup";
 
 // Components
+import Button from "../components/FormsUI/Button";
 import FormContainer, { FormLink } from "../components/FormsUI/FormContainer";
 import Textfield from "../components/FormsUI/Textfield";
 import TextfieldPw from "../components/FormsUI/Textfield/TextFieldPassword";
-import Button from "../components/FormsUI/Button";
 import ResendVerificationButton from "../components/ResendVerficationButton";
 
 // MUI imports
-import Typography from "@mui/material/Typography";
+import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
-import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
+import Typography from "@mui/material/Typography";
 import FormFieldsWrapper from "../components/FormsUI/FormFieldsWrapper";
 
 type LoginFormValues = typeof INITIAL_LOGIN_FORM_STATE;
@@ -47,7 +47,7 @@ const Login = () => {
     undefined
   );
 
-  const { error, message, isLoggedIn, user, isLoading } = useSelector(
+  const { error, message, user, isLoading } = useSelector(
     (state: RootState) => state.auth
   );
 
@@ -90,65 +90,59 @@ const Login = () => {
   };
 
   return (
-    <>
-      {!isLoggedIn && (
-        <FormContainer>
-          <Typography sx={{ mb: 4, textAlign: "center" }} variant="h6">
-            Log In to Your Account!
-          </Typography>
+    <FormContainer>
+      <Typography sx={{ mb: 4, textAlign: "center" }} variant="h6">
+        Log In to Your Account!
+      </Typography>
 
-          <Formik
-            initialValues={INITIAL_LOGIN_FORM_STATE}
-            validationSchema={LOGIN_FORM_VALIDATION}
-            onSubmit={submitHandler}
-          >
-            {/* {({ status }) => ( */}
-            <FormikForm>
-              <FormFieldsWrapper>
-                <Textfield label="Enter Email" name="email" required />
-                <TextfieldPw label="Enter Password" name="password" required />
+      <Formik
+        initialValues={INITIAL_LOGIN_FORM_STATE}
+        validationSchema={LOGIN_FORM_VALIDATION}
+        onSubmit={submitHandler}
+      >
+        {/* {({ status }) => ( */}
+        <FormikForm>
+          <FormFieldsWrapper>
+            <Textfield label="Enter Email" name="email" required />
+            <TextfieldPw label="Enter Password" name="password" required />
 
-                <Box>
-                  <FormLink to="/forgot-password" underline="none">
-                    <Typography variant="body2">
-                      Forgot your password?
-                    </Typography>
-                  </FormLink>
-                </Box>
+            <Box>
+              <FormLink to="/forgot-password" underline="none">
+                <Typography variant="body2">Forgot your password?</Typography>
+              </FormLink>
+            </Box>
 
-                <Button
-                  color="secondary"
-                  endIcon={<KeyboardArrowRightIcon />}
-                  disableElevation
-                  loading={isLoading}
-                  // we can use isSubmitting prop from formik as well
-                >
-                  Login
-                </Button>
+            <Button
+              color="secondary"
+              endIcon={<KeyboardArrowRightIcon />}
+              disableElevation
+              loading={isLoading}
+              // we can use isSubmitting prop from formik as well
+            >
+              Login
+            </Button>
 
-                <Box sx={{ display: "flex", gap: 1 }}>
-                  <Typography variant="body2">Create new account?</Typography>
-                  <FormLink to="/register" underline="none">
-                    <Typography variant="body2">Sign up!</Typography>
-                  </FormLink>
-                </Box>
+            <Box sx={{ display: "flex", gap: 1 }}>
+              <Typography variant="body2">Create new account?</Typography>
+              <FormLink to="/register" underline="none">
+                <Typography variant="body2">Sign up!</Typography>
+              </FormLink>
+            </Box>
 
-                {status && <Alert severity="error">{status}</Alert>}
-                {error && <Alert severity="error">{error}</Alert>}
-                {message && <Alert severity="info">{message}</Alert>}
+            {status && <Alert severity="error">{status}</Alert>}
+            {error && <Alert severity="error">{error}</Alert>}
+            {message && <Alert severity="info">{message}</Alert>}
 
-                {unverifiedEmail && (
-                  <Box mt={2}>
-                    <ResendVerificationButton email={unverifiedEmail} />
-                  </Box>
-                )}
-              </FormFieldsWrapper>
-            </FormikForm>
-            {/* )} */}
-          </Formik>
-        </FormContainer>
-      )}
-    </>
+            {unverifiedEmail && (
+              <Box mt={2}>
+                <ResendVerificationButton email={unverifiedEmail} />
+              </Box>
+            )}
+          </FormFieldsWrapper>
+        </FormikForm>
+        {/* )} */}
+      </Formik>
+    </FormContainer>
   );
 };
 

--- a/client/src/redux/store/auth/auth-slice.ts
+++ b/client/src/redux/store/auth/auth-slice.ts
@@ -17,7 +17,7 @@ interface User {
 
 interface AuthState {
   isLoading: boolean;
-  isLoggedIn: boolean;
+  isLoggedIn: boolean | undefined;
   user: User | null;
   accessToken: string | null;
   error: string | null;
@@ -27,7 +27,7 @@ interface AuthState {
 
 const initialState: AuthState = {
   isLoading: false,
-  isLoggedIn: false,
+  isLoggedIn: undefined,
   user: null,
   accessToken: null,
   error: null,

--- a/client/src/routes/ProtectedRoutes.tsx
+++ b/client/src/routes/ProtectedRoutes.tsx
@@ -8,11 +8,14 @@ interface ProtectedRoutesProps {
   allowedRoles?: string[]; // Optional: if not passed, allow any logged-in user
 }
 
+// Component
 const ProtectedRoutes = ({ children, allowedRoles }: ProtectedRoutesProps) => {
   const dispatch = useDispatch<AppDispatch>();
   const location = useLocation();
   const { isLoggedIn, user } = useSelector((state: RootState) => state.auth);
 
+  // checking the logged in state
+  // the logged in state is already verfied here
   if (!isLoggedIn) {
     return <Navigate to="/login" replace state={{ from: location }} />;
   }


### PR DESCRIPTION
### What was done
- Implemented `isLoggedIn: true | false | undefined` in the auth slice to track loading state during initial auth check.
- Updated `App.tsx` to block rendering of routes using a full-screen spinner until `isLoggedIn` is resolved.
- Cleaned up `Login.tsx` by removing redundant `isLoggedIn` check, since routing now controls visibility.
- Verified that `ProtectedRoutes` is only rendered after `isLoggedIn` is resolved; removed unnecessary check there as well.

### Why this change
- Fixes the issue where the login page briefly flashes on screen during initial app load if the user is already logged in.
- Ensures cleaner and more consistent user experience.

### Test Cases
- Visiting the app while logged in redirects to dashboard with no flicker
- Visiting protected routes while logged out redirects to login
- Auth loading state is handled globally with single spinner

### Affected files
- `auth-slice.ts`
- `App.tsx`
- `Login.tsx`
- `ProtectedRoutes.tsx`
